### PR TITLE
feat: add `disableJSXCache` flag

### DIFF
--- a/src/Inflator/web/WebInflator.ts
+++ b/src/Inflator/web/WebInflator.ts
@@ -30,6 +30,7 @@ type WebInflateResult<T> =
 interface WebInflatorFlags {
   debug: boolean
   skipAsync: boolean
+  disableJSXCache: boolean
 }
 
 class WebInflator extends Inflator {
@@ -38,6 +39,7 @@ class WebInflator extends Inflator {
   flags: WebInflatorFlags = {
     debug: false,
     skipAsync: false,
+    disableJSXCache: false,
   }
   /**
    * Custom JSX attributes.
@@ -151,11 +153,17 @@ class WebInflator extends Inflator {
   }
 
   private inflateJSXDeeply(jsx: JSX.Element): Element | DocumentFragment | Node {
-    const inflatedCached = WebInflator.jsxCache.get(jsx)
-    if (inflatedCached != null) return inflatedCached
+    let inflated
 
-    const inflated = this.inflateJSX(jsx)
-    WebInflator.jsxCache.set(jsx, inflated)
+    if (this.flags.disableJSXCache) {
+      inflated = this.inflateJSX(jsx)
+    } else {
+      const inflatedCached = WebInflator.jsxCache.get(jsx)
+      if (inflatedCached != null) return inflatedCached
+
+      inflated = this.inflateJSX(jsx)
+      WebInflator.jsxCache.set(jsx, inflated)
+    }
     // Inflation of Component children is handled by the component itself.
     if (jsx instanceof ProtonJSX.Component) return inflated
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a user-configurable option to disable JSX caching. When enabled, the system always regenerates views instead of using cached versions.
  - Default behavior remains unchanged (caching stays on), ensuring no impact unless the option is explicitly toggled.
  - Disabling the cache can help ensure the most up-to-date UI during development or troubleshooting, with a potential performance trade-off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->