### PR TITLE
feat(lifecycle): Add life.scoped and hook enter into component constructor

### DIFF
--- a/spec/life.spec.ts
+++ b/spec/life.spec.ts
@@ -34,3 +34,67 @@ describe('Life Class', () => {
     expect(cleanupFn).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Life Class > when()', () => {
+  it('should call when("enter") subscriber on enter', () => {
+    const life = new Life();
+    const enterCallback = mock();
+    
+    life.when("enter").subscribe(enterCallback);
+    
+    expect(enterCallback).not.toHaveBeenCalled();
+    life.enter();
+    expect(enterCallback).toHaveBeenCalledTimes(1);
+    life.enter(); // Should not call again if already alive
+    expect(enterCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call when("exit") subscriber on exit', () => {
+    const life = new Life();
+    const exitCallback = mock();
+
+    life.when("exit").subscribe(exitCallback);
+    
+    life.enter();
+    expect(exitCallback).not.toHaveBeenCalled();
+    life.exit();
+    expect(exitCallback).toHaveBeenCalledTimes(1);
+    life.exit();
+    expect(exitCallback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Life Class > adopt()', () => {
+  it('should adopt logic with onEnter and onExit', () => {
+    const life = new Life();
+    const logic = {
+      onEnter: mock(),
+      onExit: mock(),
+    };
+
+    life.adopt(logic);
+    
+    expect(logic.onEnter).not.toHaveBeenCalled();
+    life.enter();
+    expect(logic.onEnter).toHaveBeenCalledTimes(1);
+
+    expect(logic.onExit).not.toHaveBeenCalled();
+    life.exit();
+    expect(logic.onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should adopt logic with a startup function', () => {
+    const life = new Life();
+    const logic = {
+      startup: mock((signal: AbortSignal) => {
+        expect(signal).toBeInstanceOf(AbortSignal);
+      }),
+    };
+
+    life.adopt(logic);
+    
+    expect(logic.startup).not.toHaveBeenCalled();
+    life.enter();
+    expect(logic.startup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Inflator/web/WebInflator.ts
+++ b/src/Inflator/web/WebInflator.ts
@@ -280,15 +280,6 @@ class WebInflator extends Inflator {
     const currentView = component.inflator.inflate(component.view.current) as ChildNode | null
     replace(currentView)
 
-    const connection = ElementLifecycle.connection(componentGroup);
-    connection.state.subscribe(connected => {
-      if (connected) {
-        component.view.life.enter();
-      } else {
-        component.view.life.exit();
-      }
-    });
-
     function replace(view: unknown | null) {
       if (view == null) componentGroup.replaceChildren()
       if (view instanceof Node) componentGroup.replaceChildren(view)

--- a/src/Life.ts
+++ b/src/Life.ts
@@ -1,17 +1,32 @@
+import { Subscriptable, Unsubscribe } from "@/Observable";
+
 export class Life {
   public alive = false;
   private controller!: AbortController;
 
+  private onEnterSubscribers = new Set<() => void>();
+  private onExitSubscribers = new Set<() => void>();
+
   /** @internal */
   public enter(): void {
+    if (this.alive) return;
     this.alive = true;
     this.controller = new AbortController();
+
+    for (const callback of this.onEnterSubscribers) {
+      callback();
+    }
   }
 
   /** @internal */
   public exit(): void {
+    if (!this.alive) return;
     this.alive = false;
     this.controller.abort();
+
+    for (const callback of this.onExitSubscribers) {
+      callback();
+    }
   }
 
   public scoped(setup: (signal: AbortSignal) => void): void {
@@ -20,6 +35,50 @@ export class Life {
       setup(this.controller.signal);
     } catch (error) {
       console.error("Error executing a scoped lifecycle function:", error);
+    }
+  }
+
+  /**
+   * Subscribes to lifecycle events.
+   * @param event The event to listen for ("enter" or "exit")
+   */
+  public when(event: "enter" | "exit"): Subscriptable<void> {
+    const subscribers = event === "enter"
+      ? this.onEnterSubscribers
+      : this.onExitSubscribers;
+
+    return {
+      subscribe: (callback: () => void): Unsubscribe => {
+        subscribers.add(callback);
+        return {
+          unsubscribe: () => {
+            subscribers.delete(callback);
+          },
+        };
+      },
+    };
+  }
+
+  /**
+   * Adopts a piece of logic and automatically manages its lifecycle.
+   * This can be an object with onEnter/onExit methods, or a startup function.
+   * @param logic The logic to adopt.
+   */
+  public adopt(logic: {
+    onEnter?: () => void;
+    onExit?: () => void;
+    startup?: (signal: AbortSignal) => void;
+  }): void {
+    if (logic.onEnter) {
+      this.when("enter").subscribe(logic.onEnter);
+    }
+    if (logic.onExit) {
+      this.when("exit").subscribe(logic.onExit);
+    }
+    if (logic.startup) {
+      this.when("enter").subscribe(() => {
+        this.scoped(logic.startup!); 
+      });
     }
   }
 }

--- a/src/Proton/ProtonComponent.ts
+++ b/src/Proton/ProtonComponent.ts
@@ -4,7 +4,6 @@ import Inflator from "@/Inflator/Inflator"
 import TreeContextAPI from "@/TreeContextAPI"
 
 import ViewAPI from "../ProtonViewAPI"
-import { ElementLifecycle } from "@/utils/ElementLifecycle";
 
 export class ProtonComponent {
   public readonly view: ViewAPI


### PR DESCRIPTION
Issue #70
This PR introduces a new component lifecycle feature, life.scoped(), to simplify resource management and prevent common memory leaks. It provides a declarative API for developers to run setup logic (like addEventListener or setInterval) that is automatically cleaned up when the component's lifecycle ends, using a standard AbortSignal.